### PR TITLE
fix: more generic paths

### DIFF
--- a/src/routes/[name].svelte
+++ b/src/routes/[name].svelte
@@ -1,5 +1,5 @@
 <script lang="ts" context="module">
-	import { ConfigRequestService } from '../../services/config-request.service';
+	import { ConfigRequestService } from '../services/config-request.service';
 	const configRequestService = new ConfigRequestService();
 
 	export async function load({ page, fetch }) {
@@ -19,10 +19,10 @@
 </script>
 
 <script lang="ts">
-	import type { config as configTypes } from '../../interfaces/config.interface';
+	import type { config as configTypes } from '../interfaces/config.interface';
 	import { onMount } from 'svelte';
 	import get from 'lodash.get';
-	import Card from '../../components/card.svelte';
+	import Card from '../components/card.svelte';
 
 	export let routeConfig: configTypes.Config;
 	let requestData: any = {};

--- a/static/config/index.json
+++ b/static/config/index.json
@@ -14,7 +14,7 @@
 			"hoverColor": "#ffa3b6",
 			"color": "crimson",
 			"isObject": false,
-			"link": "/pokemon/%name%"
+			"link": "/%name%"
 		}
 	]
 }


### PR DESCRIPTION
closes #24
- [x] Remove `pokemon` from path => Its more generic if its just `/[id]`

<a href="https://gitpod.io/#https://github.com/Cahllagerfeld/generic-svelte-frontend/pull/25"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

